### PR TITLE
Do not pass stray argument to clearSoundBuffer

### DIFF
--- a/src/ag.c
+++ b/src/ag.c
@@ -297,7 +297,7 @@ inputs:   n/a
 outputs:  n/a
 ***********************************************************/
 static void
-clearSoundBuffer()
+clearSoundBuffer(void)
 {
     struct sound* currentSound = soundCache, *previousSound = NULL;
 
@@ -1890,7 +1890,7 @@ main(int argc, char *argv[])
 	if (audio_enabled)
 	{
 		Mix_CloseAudio();
-		clearSoundBuffer(&soundCache);
+		clearSoundBuffer();
 	}
 	dlb_free(dlbHead);
 	destroyLetters(&letters);


### PR DESCRIPTION
This function does not take any arguments and instead uses the global variable `soundCache`.