### PR TITLE
Add a link back to GitHub

### DIFF
--- a/anagramarama.metainfo.xml
+++ b/anagramarama.metainfo.xml
@@ -33,6 +33,7 @@
   </screenshots>
 
   <url type="homepage">http://identicalsoftware.com/anagramarama/</url>
+  <url type="vcs-browser">https://github.com/dulsi/anagramarama</url>
 
   <provides>
     <binary>anagramarama</binary>


### PR DESCRIPTION
To resolve https://docs.flathub.org/docs/for-app-authors/linter#appstream-missing-vcs-browser-url